### PR TITLE
Add missing user controller tests

### DIFF
--- a/server/tests/controllers/user.controller.spec.ts
+++ b/server/tests/controllers/user.controller.spec.ts
@@ -298,7 +298,23 @@ describe('Test userController', () => {
       expect(getUsersListSpy).toHaveBeenCalled();
     });
 
-    // TODO: Task 1 - Add more tests
+    it('should return 500 if service returns an error', async () => {
+      getUsersListSpy.mockResolvedValueOnce({ error: 'Database error' });
+
+      const response = await supertest(app).get(`/user/getUsers`);
+
+      expect(response.status).toBe(500);
+      expect(response.body).toEqual({ error: 'Database error' });
+    });
+
+    it('should return 500 if service throws an error', async () => {
+      getUsersListSpy.mockRejectedValueOnce(new Error('Unexpected'));
+
+      const response = await supertest(app).get(`/user/getUsers`);
+
+      expect(response.status).toBe(500);
+      expect(response.body).toEqual({ error: 'Internal server error' });
+    });
   });
 
   describe('DELETE /deleteUser', () => {
@@ -348,6 +364,82 @@ describe('Test userController', () => {
       });
     });
 
-    // TODO: Task 1 - Add more tests
+    it('should return 400 if username is missing', async () => {
+      const mockReqBody = {
+        biography: 'bio',
+      } as any;
+
+      const response = await supertest(app)
+        .patch('/user/updateBiography')
+        .send(mockReqBody);
+
+      expect(response.status).toBe(400);
+      expect(response.body).toEqual({
+        error: 'Invalid request body. username and biography are required.',
+      });
+    });
+
+    it('should return 400 if biography is missing', async () => {
+      const mockReqBody = {
+        username: mockUser.username,
+      } as any;
+
+      const response = await supertest(app)
+        .patch('/user/updateBiography')
+        .send(mockReqBody);
+
+      expect(response.status).toBe(400);
+      expect(response.body).toEqual({
+        error: 'Invalid request body. username and biography are required.',
+      });
+    });
+
+    it('should return 404 if the user is not found', async () => {
+      const mockReqBody = {
+        username: mockUser.username,
+        biography: 'bio',
+      };
+
+      updatedUserSpy.mockResolvedValueOnce({ error: 'User not found' });
+
+      const response = await supertest(app)
+        .patch('/user/updateBiography')
+        .send(mockReqBody);
+
+      expect(response.status).toBe(404);
+      expect(response.body).toEqual({ error: 'User not found' });
+    });
+
+    it('should return 500 if updateUser returns an error', async () => {
+      const mockReqBody = {
+        username: mockUser.username,
+        biography: 'bio',
+      };
+
+      updatedUserSpy.mockResolvedValueOnce({ error: 'Database failure' });
+
+      const response = await supertest(app)
+        .patch('/user/updateBiography')
+        .send(mockReqBody);
+
+      expect(response.status).toBe(500);
+      expect(response.body).toEqual({ error: 'Database failure' });
+    });
+
+    it('should return 500 if updateUser throws an error', async () => {
+      const mockReqBody = {
+        username: mockUser.username,
+        biography: 'bio',
+      };
+
+      updatedUserSpy.mockRejectedValueOnce(new Error('Unexpected'));
+
+      const response = await supertest(app)
+        .patch('/user/updateBiography')
+        .send(mockReqBody);
+
+      expect(response.status).toBe(500);
+      expect(response.body).toEqual({ error: 'Internal server error' });
+    });
   });
 });


### PR DESCRIPTION
## Summary
- cover error conditions for `/user/getUsers`
- verify invalid bodies and error scenarios for `/user/updateBiography`

## Testing
- `npm install`
- `npm test --silent` *(fails: Test suite failed to run due to memory leak in chat tests)*

------
https://chatgpt.com/codex/tasks/task_e_685f927617e0833081b8e902fb39a07c