### PR TITLE
Fix direct message retrieval

### DIFF
--- a/server/models/schema/chat.schema.ts
+++ b/server/models/schema/chat.schema.ts
@@ -3,7 +3,7 @@ import { Schema } from 'mongoose';
 /**
  * Mongoose schema for the Chat collection.
  *
- * - `participants`: an array of ObjectIds referencing the User collection.
+ * - `participants`: an array of usernames participating in the chat.
  * - `messages`: an array of ObjectIds referencing the Message collection.
  * - Timestamps store `createdAt` & `updatedAt`.
  */
@@ -11,9 +11,8 @@ const chatSchema: Schema = new Schema(
   {
     participants: [
       {
-        type: Schema.Types.ObjectId,
-        ref: 'User',
-        required: true
+        type: String,
+        required: true,
       }
     ],
     messages: [


### PR DESCRIPTION
## Summary
- store chat participants as usernames instead of ObjectId references
- simplify chat service queries to match this schema

## Testing
- `npm test` *(fails: Jest reports leaking memory)*

------
https://chatgpt.com/codex/tasks/task_e_685f9d6327288330a8cbc49843d69f65